### PR TITLE
New reading writing calls

### DIFF
--- a/cfinterface/__init__.py
+++ b/cfinterface/__init__.py
@@ -6,7 +6,7 @@ cfi is a Python module for handling custom formatted files
 and provide reading, storing and writing utilities.
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 from . import components  # noqa
 from . import data  # noqa

--- a/cfinterface/adapters/reading/repository.py
+++ b/cfinterface/adapters/reading/repository.py
@@ -43,8 +43,11 @@ class BinaryRepository(Repository):
         self._filepointer: BinaryIO = None  # type: ignore
 
     def __enter__(self):
-        io = BytesIO(self._content) if self._wrap_io else self._content
-        self._filepointer = open(io, "rb")
+        self._filepointer = (
+            BytesIO(self._content)
+            if self._wrap_io
+            else open(self._content, "rb")
+        )
         return super().__enter__()
 
     def __exit__(self, *args):
@@ -70,15 +73,22 @@ class BinaryRepository(Repository):
 
 class TextualRepository(Repository):
     def __init__(
-        self, content: str, encoding: str, wrap_io: bool = False
+        self,
+        content: str,
+        wrap_io: bool = False,
+        encoding: str = "utf-8",
+        *args
     ) -> None:
         super().__init__(content, wrap_io)
         self._encoding = encoding
         self._filepointer: TextIO = None  # type: ignore
 
     def __enter__(self):
-        io = StringIO(self._content) if self._wrap_io else self._content
-        self._filepointer = open(io, "r", encoding=self._encoding)
+        self._filepointer = (
+            StringIO(self._content)
+            if self._wrap_io
+            else open(self._content, "r", encoding=self._encoding)
+        )
         return super().__enter__()
 
     def __exit__(self, *args):

--- a/cfinterface/adapters/writing/repository.py
+++ b/cfinterface/adapters/writing/repository.py
@@ -3,8 +3,9 @@ from abc import ABC, abstractmethod
 
 
 class Repository(ABC):
-    def __init__(self, path: str, *args) -> None:
-        self._path = path
+    def __init__(self, to: Union[str, IO], *args) -> None:
+        self._to = to
+        self._wrap_io = isinstance(to, str)
 
     def __enter__(self) -> "Repository":
         return self
@@ -34,7 +35,7 @@ class BinaryRepository(Repository):
         self._filepointer: BinaryIO = None  # type: ignore
 
     def __enter__(self):
-        self._filepointer = open(self._path, "wb")
+        self._filepointer = open(self._to, "wb") if self._wrap_io else self._to
         return super().__enter__()
 
     def __exit__(self, *args):
@@ -63,7 +64,11 @@ class TextualRepository(Repository):
         self._encoding = encoding
 
     def __enter__(self):
-        self._filepointer = open(self._path, "w", encoding=self._encoding)
+        self._filepointer = (
+            open(self._to, "w", encoding=self._encoding)
+            if self._wrap_io
+            else self._to
+        )
         return super().__enter__()
 
     def __exit__(self, *args):

--- a/cfinterface/adapters/writing/repository.py
+++ b/cfinterface/adapters/writing/repository.py
@@ -40,7 +40,8 @@ class BinaryRepository(Repository):
 
     def __exit__(self, *args):
         super().__exit__(*args)
-        self._filepointer.close()
+        if self._wrap_io:
+            self._filepointer.close()
 
     def write(self, data: Union[str, bytes]):
         """
@@ -73,7 +74,8 @@ class TextualRepository(Repository):
 
     def __exit__(self, *args):
         super().__exit__(*args)
-        self._filepointer.close()
+        if self._wrap_io:
+            self._filepointer.close()
 
     def write(self, data: Union[str, bytes]):
         """

--- a/cfinterface/files/blockfile.py
+++ b/cfinterface/files/blockfile.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Type, Optional
+from typing import List, Dict, Type, Optional, Union, IO
 
 from cfinterface.components.block import Block
 from cfinterface.components.defaultblock import DefaultBlock
@@ -34,31 +34,26 @@ class BlockFile:
         return self.data == bf.data
 
     @classmethod
-    def read(cls, directory: str, filename: str = "", *args, **kwargs):
+    def read(cls, content: Union[str, bytes], *args, **kwargs):
         """
-        Reads the blockfile data from a given file in disk.
+        Reads the blockfile data from either a given file or a buffer.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents themselves
+        :type content: str | bytes
         """
         reader = BlockReading(cls.BLOCKS, cls.STORAGE)
-        return cls(
-            reader.read(filename, directory, cls.ENCODING, *args, **kwargs)
-        )
+        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
 
-    def write(self, directory: str, filename: str = "", *args, **kwargs):
+    def write(self, to: Union[str, IO], *args, **kwargs):
         """
-        Write the blockfile data to a given file in disk.
+        Write the blockfile data to a given file or buffer.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         """
         writer = BlockWriting(self.__data, self.__storage)
-        writer.write(filename, directory, self.__encoding, *args, **kwargs)
+        writer.write(to, self.__encoding, *args, **kwargs)
 
     @property
     def data(self) -> BlockData:

--- a/cfinterface/files/registerfile.py
+++ b/cfinterface/files/registerfile.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Type, Optional
+from typing import List, Dict, Type, Optional, Union, IO
 import pandas as pd  # type: ignore
 from cfinterface.components.register import Register
 from cfinterface.components.defaultregister import DefaultRegister
@@ -53,31 +53,26 @@ class RegisterFile:
         )
 
     @classmethod
-    def read(cls, directory: str, filename: str = "", *args, **kwargs):
+    def read(cls, content: Union[str, bytes], *args, **kwargs):
         """
         Reads the registerfile data from a given file in disk.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents themselves
+        :type content: str | bytes
         """
         reader = RegisterReading(cls.REGISTERS, cls.STORAGE, *args, **kwargs)
-        return cls(
-            reader.read(filename, directory, cls.ENCODING, *args, **kwargs)
-        )
+        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
 
-    def write(self, directory: str, filename: str = "", *args, **kwargs):
+    def write(self, to: Union[str, IO], *args, **kwargs):
         """
-        Write the registerfile data to a given file in disk.
+        Write the registerfile data to a given file or buffer.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         """
         writer = RegisterWriting(self.__data, self.__storage, *args, **kwargs)
-        writer.write(filename, directory, self.__encoding, *args, **kwargs)
+        writer.write(to, self.__encoding, *args, **kwargs)
 
     @property
     def data(self) -> RegisterData:

--- a/cfinterface/files/sectionfile.py
+++ b/cfinterface/files/sectionfile.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Type, Optional
+from typing import List, Dict, Type, Optional, Union, IO
 
 from cfinterface.components.section import Section
 from cfinterface.components.defaultsection import DefaultSection
@@ -34,31 +34,26 @@ class SectionFile:
         return self.data == bf.data
 
     @classmethod
-    def read(cls, directory: str, filename: str = "", *args, **kwargs):
+    def read(cls, content: Union[str, bytes], *args, **kwargs):
         """
         Reads the sectionfile data from a given file in disk.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents themselves
+        :type content: str | bytes
         """
         reader = SectionReading(cls.SECTIONS, cls.STORAGE)
-        return cls(
-            reader.read(filename, directory, cls.ENCODING, *args, **kwargs)
-        )
+        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
 
-    def write(self, directory: str, filename: str = "", *args, **kwargs):
+    def write(self, to: Union[str, IO], filename: str = "", *args, **kwargs):
         """
-        Write the sectionfile data to a given file in disk.
+        Write the sectionfile data to a given file or buffer.
 
-        :param filename: The file name in disk
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         """
         writer = SectionWriting(self.__data, self.__storage)
-        writer.write(filename, directory, self.__encoding, *args, **kwargs)
+        writer.write(to, self.__encoding, *args, **kwargs)
 
     @property
     def data(self) -> SectionData:

--- a/cfinterface/reading/blockreading.py
+++ b/cfinterface/reading/blockreading.py
@@ -85,7 +85,7 @@ class BlockReading:
         self, content: Union[str, bytes], encoding: str, *args, **kwargs
     ) -> BlockData:
         """
-        Reads a file with a given name in a given directory and
+        Reads a file in a given path and
         extracts the data from the specified blocks.
 
         :param content: The file name in disk or the file contents

--- a/cfinterface/reading/blockreading.py
+++ b/cfinterface/reading/blockreading.py
@@ -1,5 +1,5 @@
 from typing import List, Type, Union
-from os.path import join
+from os.path import isfile
 
 from cfinterface.components.block import Block
 from cfinterface.components.defaultblock import DefaultBlock
@@ -82,23 +82,22 @@ class BlockReading:
         return self.__data
 
     def read(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
+        self, content: Union[str, bytes], encoding: str, *args, **kwargs
     ) -> BlockData:
         """
         Reads a file with a given name in a given directory and
         extracts the data from the specified blocks.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents
+        :type content: str | bytes
         :param encoding: The encoding for reading the file
         :type encoding: str
         :return: The data from the blocks found in the file
         :rtype: BlockData
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+        self.__repository = factory(self.__storage)(
+            content, not isfile(content), encoding
+        )
         with self.__repository:
             return self.__read_file(*args, **kwargs)
 

--- a/cfinterface/reading/registerreading.py
+++ b/cfinterface/reading/registerreading.py
@@ -1,5 +1,5 @@
 from typing import List, Type, Union
-from os.path import join
+from os.path import isfile
 
 from cfinterface.components.register import Register
 from cfinterface.components.defaultregister import DefaultRegister
@@ -86,23 +86,22 @@ class RegisterReading:
         return self.__data
 
     def read(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
+        self, content: Union[str, bytes], encoding: str, *args, **kwargs
     ) -> RegisterData:
         """
         Reads a file with a given name in a given directory and
         extracts the data from the specified registers.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents
+        :type content: str | bytes
         :param encoding: The encoding for reading the file
         :type encoding: str
         :return: The data from the registers found in the file
         :rtype: RegisterData
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+        self.__repository = factory(self.__storage)(
+            content, not isfile(content), encoding
+        )
         with self.__repository:
             return self.__read_file(*args, **kwargs)
 

--- a/cfinterface/reading/sectionreading.py
+++ b/cfinterface/reading/sectionreading.py
@@ -1,5 +1,5 @@
 from typing import List, Type, Union
-from os.path import join
+from os.path import isfile
 
 from cfinterface.components.section import Section
 from cfinterface.components.defaultsection import DefaultSection
@@ -69,23 +69,22 @@ class SectionReading:
         return self.__data
 
     def read(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
+        self, content: Union[str, bytes], encoding: str, *args, **kwargs
     ) -> SectionData:
         """
         Reads a file with a given name in a given directory and
         extracts the data from the specified sections.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file is
-        :type directory: str
+        :param content: The file name in disk or the file contents
+        :type content: str | bytes
         :param encoding: The encoding for reading the file
         :type encoding: str
         :return: The data from the sections found in the file
         :rtype: SectionData
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+        self.__repository = factory(self.__storage)(
+            content, not isfile(content), encoding
+        )
         with self.__repository:
             return self.__read_file(*args, **kwargs)
 

--- a/cfinterface/writing/blockwriting.py
+++ b/cfinterface/writing/blockwriting.py
@@ -1,5 +1,4 @@
-from os.path import join
-
+from typing import Union, IO
 from cfinterface.data.blockdata import BlockData
 from cfinterface.adapters.writing.repository import (
     Repository,
@@ -26,22 +25,19 @@ class BlockWriting:
         for b in self.__data:
             b.write(self.__repository.file, *args, **kwargs)
 
-    def write(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
-    ):
+    def write(self, to: Union[str, IO], encoding: str, *args, **kwargs):
         """
         Writes a file with a given name in a given directory with
         the data from the BlockData structure.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         :param encoding: The encoding for reading the file
         :type encoding: str
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+
+        self.__repository = factory(self.__storage)(to, encoding)
         with self.__repository:
             return self.__write_file(*args, **kwargs)
 

--- a/cfinterface/writing/blockwriting.py
+++ b/cfinterface/writing/blockwriting.py
@@ -36,7 +36,6 @@ class BlockWriting:
         :param encoding: The encoding for reading the file
         :type encoding: str
         """
-
         self.__repository = factory(self.__storage)(to, encoding)
         with self.__repository:
             return self.__write_file(*args, **kwargs)

--- a/cfinterface/writing/registerwriting.py
+++ b/cfinterface/writing/registerwriting.py
@@ -1,4 +1,4 @@
-from os.path import join
+from typing import Union, IO
 
 from cfinterface.data.registerdata import RegisterData
 from cfinterface.adapters.writing.repository import (
@@ -26,22 +26,18 @@ class RegisterWriting:
         for r in self.__data:
             r.write(self.__repository.file, self.__storage, *args, **kwargs)
 
-    def write(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
-    ):
+    def write(self, to: Union[str, IO], encoding: str, *args, **kwargs):
         """
         Writes a file with a given name in a given directory with
         the data from the RegisterData structure.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         :param encoding: The encoding for reading the file
         :type encoding: str
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+        self.__repository = factory(self.__storage)(to, encoding)
         with self.__repository:
             return self.__write_file(*args, **kwargs)
 

--- a/cfinterface/writing/sectionwriting.py
+++ b/cfinterface/writing/sectionwriting.py
@@ -1,4 +1,4 @@
-from os.path import join
+from typing import Union, IO
 
 from cfinterface.data.sectiondata import SectionData
 from cfinterface.adapters.writing.repository import (
@@ -21,27 +21,22 @@ class SectionWriting:
         """
         Writes all the registers from the given SectionData structure
         to the specified file.
-
         """
         for s in self.__data:
             s.write(self.__repository.file, *args, **kwargs)
 
-    def write(
-        self, filename: str, directory: str, encoding: str, *args, **kwargs
-    ):
+    def write(self, to: Union[str, IO], encoding: str, *args, **kwargs):
         """
-        Writes a file with a given name in a given directory with
-        the data from the SectionData structure.
+        Writes to a file with a given name in a given directory or
+        to a buffer with the data from the SectionData structure.
 
-        :param filename: The name of the file
-        :type filename: str
-        :param directory: The directory where the file will be
-        :type directory: str
+        :param to: The writing destination, being a string for writing
+            to a file or the IO buffer
+        :type to: str | IO
         :param encoding: The encoding for reading the file
         :type encoding: str
         """
-        filepath = join(directory, filename)
-        self.__repository = factory(self.__storage)(filepath, encoding)
+        self.__repository = factory(self.__storage)(to, encoding)
         with self.__repository:
             return self.__write_file(*args, **kwargs)
 

--- a/tests/files/test_blockfile.py
+++ b/tests/files/test_blockfile.py
@@ -99,7 +99,7 @@ def test_blockfile_read():
     BlockFile.BLOCKS = [DummyBlock]
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        f = BlockFile.read("", "")
+        f = BlockFile.read("README.md")
         assert len(f.data) == 2
         assert len(f.data.last.data) == 3
         assert f.data.last.data[1] == data + "\n"
@@ -112,7 +112,7 @@ def test_blockfile_write():
     f = BlockFile(bd)
     m: MagicMock = mock_open(read_data="")
     with patch("builtins.open", m):
-        f.write("", "")
+        f.write("")
     m().write.assert_called_once_with(data)
 
 

--- a/tests/files/test_blockfile.py
+++ b/tests/files/test_blockfile.py
@@ -5,7 +5,7 @@ from cfinterface.data.blockdata import BlockData
 from cfinterface.files.blockfile import BlockFile
 
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -105,6 +105,19 @@ def test_blockfile_read():
         assert f.data.last.data[1] == data + "\n"
 
 
+def test_blockfile_read_frombuffer():
+    data = "Hello, world!"
+    filedata = (
+        "\n".join([DummyBlock.BEGIN_PATTERN, data, DummyBlock.END_PATTERN])
+        + "\n"
+    )
+    BlockFile.BLOCKS = [DummyBlock]
+    f = BlockFile.read(filedata)
+    assert len(f.data) == 2
+    assert len(f.data.last.data) == 3
+    assert f.data.last.data[1] == data + "\n"
+
+
 def test_blockfile_write():
     data = "Hello, world!"
     bd = BlockData(DummyBlock(data=[data]))
@@ -114,6 +127,16 @@ def test_blockfile_write():
     with patch("builtins.open", m):
         f.write("")
     m().write.assert_called_once_with(data)
+
+
+def test_blockfile_write_tobuffer():
+    data = "Hello, world!"
+    bd = BlockData(DummyBlock(data=[data]))
+    BlockFile.BLOCKS = [DummyBlock]
+    f = BlockFile(bd)
+    m = StringIO()
+    f.write(m)
+    assert m.getvalue() == data
 
 
 def test_blockfile_set_version():

--- a/tests/files/test_registerfile.py
+++ b/tests/files/test_registerfile.py
@@ -6,7 +6,7 @@ from cfinterface.files.registerfile import RegisterFile
 
 import pandas as pd  # type: ignore
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -79,6 +79,15 @@ def test_registerfile_read():
         assert f.data.last.data[0] == data
 
 
+def test_registerfile_read_frombuffer():
+    data = "Hello, world!"
+    filedata = DummyRegister.IDENTIFIER + " " + data + "\n"
+    RegisterFile.REGISTERS = [DummyRegister]
+    f = RegisterFile.read(filedata)
+    assert len(f.data) == 2
+    assert f.data.last.data[0] == data
+
+
 def test_registerfile_write():
     data = "Hello, world!"
     bd = RegisterData(DummyRegister(data=[data]))
@@ -90,6 +99,16 @@ def test_registerfile_write():
     m().write.assert_called_once_with(
         DummyRegister.IDENTIFIER + " " + data + "\n"
     )
+
+
+def test_registerfile_write_tobuffer():
+    data = "Hello, world!"
+    bd = RegisterData(DummyRegister(data=[data]))
+    RegisterFile.REGISTERS = [DummyRegister]
+    f = RegisterFile(bd)
+    m = StringIO()
+    f.write(m)
+    m.getvalue() == DummyRegister.IDENTIFIER + " " + data + "\n"
 
 
 def test_registerfile_set_version():

--- a/tests/files/test_registerfile.py
+++ b/tests/files/test_registerfile.py
@@ -74,7 +74,7 @@ def test_registerfile_read():
     RegisterFile.REGISTERS = [DummyRegister]
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        f = RegisterFile.read("", "")
+        f = RegisterFile.read("README.md")
         assert len(f.data) == 2
         assert f.data.last.data[0] == data
 
@@ -86,7 +86,7 @@ def test_registerfile_write():
     f = RegisterFile(bd)
     m: MagicMock = mock_open(read_data="")
     with patch("builtins.open", m):
-        f.write("", "")
+        f.write("")
     m().write.assert_called_once_with(
         DummyRegister.IDENTIFIER + " " + data + "\n"
     )

--- a/tests/files/test_sectionfile.py
+++ b/tests/files/test_sectionfile.py
@@ -83,7 +83,7 @@ def test_sectionfile_read():
     SectionFile.SECTIONS = [DummySection]
     m: MagicMock = mock_open(read_data=data + "\n")
     with patch("builtins.open", m):
-        f = SectionFile.read("", "")
+        f = SectionFile.read("README.md")
         assert len(f.data) == 2
         assert len(f.data.last.data) == 1
         assert f.data.last.data[0] == data + "\n"
@@ -96,7 +96,7 @@ def test_sectionfile_write():
     f = SectionFile(bd)
     m: MagicMock = mock_open(read_data="")
     with patch("builtins.open", m):
-        f.write("", "")
+        f.write("")
     m().write.assert_called_once_with(data)
 
 

--- a/tests/files/test_sectionfile.py
+++ b/tests/files/test_sectionfile.py
@@ -5,7 +5,7 @@ from cfinterface.data.sectiondata import SectionData
 from cfinterface.files.sectionfile import SectionFile
 
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -89,6 +89,15 @@ def test_sectionfile_read():
         assert f.data.last.data[0] == data + "\n"
 
 
+def test_sectionfile_read_frombuffer():
+    data = "Hello, world!"
+    SectionFile.SECTIONS = [DummySection]
+    f = SectionFile.read(data + "\n")
+    assert len(f.data) == 2
+    assert len(f.data.last.data) == 1
+    assert f.data.last.data[0] == data + "\n"
+
+
 def test_sectionfile_write():
     data = "Hello, world!"
     bd = SectionData(DummySection(data=[data]))
@@ -98,6 +107,16 @@ def test_sectionfile_write():
     with patch("builtins.open", m):
         f.write("")
     m().write.assert_called_once_with(data)
+
+
+def test_sectionfile_write_tobuffer():
+    data = "Hello, world!"
+    bd = SectionData(DummySection(data=[data]))
+    SectionFile.SECTIONS = [DummySection]
+    f = SectionFile(bd)
+    m = StringIO()
+    f.write(m)
+    m.getvalue() == data
 
 
 def test_sectionfile_set_version():

--- a/tests/reading/test_blockreading.py
+++ b/tests/reading/test_blockreading.py
@@ -38,7 +38,7 @@ def test_blockreading_empty():
     br = BlockReading([DummyBlock])
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bd = br.read("", "", "utf-8")
+        bd = br.read("README.md", "utf-8")
         assert br.empty
         assert len(bd) == 1
 
@@ -52,7 +52,7 @@ def test_blockreading_withdata():
     br = BlockReading([DummyBlock])
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bd = br.read("", "", "utf-8")
+        bd = br.read("README.md", "utf-8")
         assert not br.empty
         dbs = [b for b in bd.of_type(DummyBlock)]
         assert len(dbs) == 1

--- a/tests/reading/test_blockreading.py
+++ b/tests/reading/test_blockreading.py
@@ -59,3 +59,19 @@ def test_blockreading_withdata():
         assert dbs[0].data[0].strip() == DummyBlock.BEGIN_PATTERN
         assert dbs[0].data[1].strip() == data
         assert dbs[0].data[2].strip() == DummyBlock.END_PATTERN
+
+
+def test_blockreading_withdata_frombuffer():
+    data = "Hello, world!"
+    filedata = (
+        "\n".join([DummyBlock.BEGIN_PATTERN, data, DummyBlock.END_PATTERN])
+        + "\n"
+    )
+    br = BlockReading([DummyBlock])
+    bd = br.read(filedata, "utf-8")
+    assert not br.empty
+    dbs = [b for b in bd.of_type(DummyBlock)]
+    assert len(dbs) == 1
+    assert dbs[0].data[0].strip() == DummyBlock.BEGIN_PATTERN
+    assert dbs[0].data[1].strip() == data
+    assert dbs[0].data[2].strip() == DummyBlock.END_PATTERN

--- a/tests/reading/test_registerreading.py
+++ b/tests/reading/test_registerreading.py
@@ -19,7 +19,7 @@ def test_registerreading_empty():
     br = RegisterReading([DummyRegister])
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bd = br.read("", "", "utf-8")
+        bd = br.read("README.md", "utf-8")
         assert br.empty
         assert len(bd) == 1
 
@@ -31,7 +31,7 @@ def test_registerreading_withdata():
         read_data=DummyRegister.IDENTIFIER + " " + data + "\n"
     )
     with patch("builtins.open", m):
-        bd = br.read("", "", "utf-8")
+        bd = br.read("README.md", "utf-8")
         assert not br.empty
         dbs = [b for b in bd.of_type(DummyRegister)]
         assert len(dbs) == 1

--- a/tests/reading/test_registerreading.py
+++ b/tests/reading/test_registerreading.py
@@ -36,3 +36,14 @@ def test_registerreading_withdata():
         dbs = [b for b in bd.of_type(DummyRegister)]
         assert len(dbs) == 1
         assert dbs[0].data[0].strip() == data
+
+
+def test_registerreading_withdata_frombuffer():
+    data = "Hello, world!"
+    br = RegisterReading([DummyRegister])
+    m = DummyRegister.IDENTIFIER + " " + data + "\n"
+    bd = br.read(m, "utf-8")
+    assert not br.empty
+    dbs = [b for b in bd.of_type(DummyRegister)]
+    assert len(dbs) == 1
+    assert dbs[0].data[0].strip() == data

--- a/tests/reading/test_sectionreading.py
+++ b/tests/reading/test_sectionreading.py
@@ -31,7 +31,7 @@ def test_sectionreading_withdata():
     sr = SectionReading([DummySection])
     m: MagicMock = mock_open(read_data=data + "\n")
     with patch("builtins.open", m):
-        sd = sr.read("", "", "utf-8")
+        sd = sr.read("README.md", "utf-8")
         assert not sr.empty
         dbs = [b for b in sd.of_type(DummySection)]
         assert len(dbs) == 1

--- a/tests/reading/test_sectionreading.py
+++ b/tests/reading/test_sectionreading.py
@@ -36,3 +36,14 @@ def test_sectionreading_withdata():
         dbs = [b for b in sd.of_type(DummySection)]
         assert len(dbs) == 1
         assert dbs[0].data[0].strip() == data
+
+
+def test_sectionreading_withdata_frombuffer():
+    data = "Hello, world!"
+    sr = SectionReading([DummySection])
+    m = data + "\n"
+    sd = sr.read(m, "utf-8")
+    assert not sr.empty
+    dbs = [b for b in sd.of_type(DummySection)]
+    assert len(dbs) == 1
+    assert dbs[0].data[0].strip() == data

--- a/tests/writing/test_blockwriting.py
+++ b/tests/writing/test_blockwriting.py
@@ -5,7 +5,7 @@ from cfinterface.data.blockdata import BlockData
 from cfinterface.writing.blockwriting import BlockWriting
 
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -39,5 +39,14 @@ def test_blockwriting_withdata():
     bw = BlockWriting(bd)
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bw.write("", "utf-8")
+        bw.write("./test.txt", "utf-8")
     m().write.assert_called_once_with(filedata)
+
+
+def test_blockwriting_withdata_tobuffer():
+    filedata = "Hello, World!"
+    bd = BlockData(DummyBlock(data=filedata))
+    bw = BlockWriting(bd)
+    m = StringIO("")
+    bw.write(m, "utf-8")
+    assert m.getvalue() == filedata

--- a/tests/writing/test_blockwriting.py
+++ b/tests/writing/test_blockwriting.py
@@ -39,5 +39,5 @@ def test_blockwriting_withdata():
     bw = BlockWriting(bd)
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bw.write("", "", "utf-8")
+        bw.write("", "utf-8")
     m().write.assert_called_once_with(filedata)

--- a/tests/writing/test_registerwriting.py
+++ b/tests/writing/test_registerwriting.py
@@ -23,7 +23,7 @@ def test_blockwriting_withdata():
     bw = RegisterWriting(bd)
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bw.write("", "", "utf-8")
+        bw.write("", "utf-8")
     m().write.assert_called_once_with(
         DummyRegister.IDENTIFIER + " " + filedata + "\n"
     )

--- a/tests/writing/test_registerwriting.py
+++ b/tests/writing/test_registerwriting.py
@@ -1,5 +1,3 @@
-from typing import IO, List
-
 from cfinterface.components.line import Line
 from cfinterface.components.literalfield import LiteralField
 from cfinterface.components.register import Register
@@ -7,7 +5,7 @@ from cfinterface.data.registerdata import RegisterData
 from cfinterface.writing.registerwriting import RegisterWriting
 
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -17,7 +15,7 @@ class DummyRegister(Register):
     LINE = Line([LiteralField(13, 4)])
 
 
-def test_blockwriting_withdata():
+def test_registerwriting_withdata():
     filedata = "Hello, World!"
     bd = RegisterData(DummyRegister(data=[filedata]))
     bw = RegisterWriting(bd)
@@ -27,3 +25,12 @@ def test_blockwriting_withdata():
     m().write.assert_called_once_with(
         DummyRegister.IDENTIFIER + " " + filedata + "\n"
     )
+
+
+def test_registerwriting_withdata_tobuffer():
+    filedata = "Hello, World!"
+    bd = RegisterData(DummyRegister(data=[filedata]))
+    bw = RegisterWriting(bd)
+    m = StringIO("")
+    bw.write(m, "utf-8")
+    assert m.getvalue() == (DummyRegister.IDENTIFIER + " " + filedata + "\n")

--- a/tests/writing/test_sectionwriting.py
+++ b/tests/writing/test_sectionwriting.py
@@ -5,7 +5,7 @@ from cfinterface.data.sectiondata import SectionData
 from cfinterface.writing.sectionwriting import SectionWriting
 
 from tests.mocks.mock_open import mock_open
-
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 
@@ -35,3 +35,12 @@ def test_sectionwriting_withdata():
     with patch("builtins.open", m):
         bw.write("", "utf-8")
     m().write.assert_called_once_with(filedata)
+
+
+def test_sectionwriting_withdata_tobuffer():
+    filedata = "Hello, World!"
+    bd = SectionData(DummySection(data=filedata))
+    bw = SectionWriting(bd)
+    m = StringIO("")
+    bw.write(m, "utf-8")
+    assert m.getvalue() == filedata

--- a/tests/writing/test_sectionwriting.py
+++ b/tests/writing/test_sectionwriting.py
@@ -33,5 +33,5 @@ def test_sectionwriting_withdata():
     bw = SectionWriting(bd)
     m: MagicMock = mock_open(read_data=filedata)
     with patch("builtins.open", m):
-        bw.write("", "", "utf-8")
+        bw.write("", "utf-8")
     m().write.assert_called_once_with(filedata)


### PR DESCRIPTION
Changes the read and write calls for supporting both files and buffers. 

In exchange, the `directory` + `filename` approach has been changed to `filepath`, which can be a buffer.