### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-03-08
+
+### Fixed
+
+- Translate all documentation and examples from pt-BR to English, matching the project's established language
+- Change Sphinx language setting from `pt_BR` to `en`
+
 ## [1.9.0] - 2026-03-08
 
 ### Added
@@ -67,5 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Null value detection in `Field` write methods now uses `math.isnan()` instead of `pd.isnull()`, eliminating the unnecessary pandas import at module level
 - `RegisterFile._as_df()` now performs a lazy pandas import, only importing the library when the method is actually called
 
-[Unreleased]: https://github.com/rjmalves/cfinterface/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/rjmalves/cfinterface/compare/v1.9.1...HEAD
+[1.9.1]: https://github.com/rjmalves/cfinterface/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/rjmalves/cfinterface/compare/v1.8.3...v1.9.0

--- a/cfinterface/__init__.py
+++ b/cfinterface/__init__.py
@@ -6,7 +6,7 @@ cfi is a Python module for handling custom formatted files
 and provide reading, storing and writing utilities.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 from . import components  # noqa
 from . import data  # noqa


### PR DESCRIPTION
## Summary

- Bump version to 1.9.1
- Update CHANGELOG with v1.9.1 entry for documentation translation fix
- Update link references in CHANGELOG

## Context

Patch release following PR #26 which translated all documentation and examples from pt-BR to English.

## Test plan

- [ ] CI passes (no code changes, only version bump and CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)