### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-04-13
+
+### Added
+
+- `compact` parameter on `FloatField` (`compact=False` by default) that omits the leading zero for values where `0 < |value| < 1`, matching Fortran fixed-width file conventions and preserving precision in narrow fields
+
+### Fixed
+
+- `RegisterReading.read()` now resets its internal data before each call, preventing register duplication when `RegisterFile.read()` retries with fallback encodings after a mid-file `UnicodeDecodeError`
+
 ## [1.9.1] - 2026-03-08
 
 ### Fixed

--- a/cfinterface/__init__.py
+++ b/cfinterface/__init__.py
@@ -6,7 +6,7 @@ cfi is a Python module for handling custom formatted files
 and provide reading, storing and writing utilities.
 """
 
-__version__ = "1.9.1"
+__version__ = "1.10.0"
 
 from . import components  # noqa
 from . import data  # noqa

--- a/cfinterface/components/floatfield.py
+++ b/cfinterface/components/floatfield.py
@@ -13,7 +13,7 @@ class FloatField(Field):
     by 'F' for fixed point notation and 'E' or 'D' for scientific notation.
     """
 
-    __slots__ = ["__decimal_digits", "__format", "__sep", "__type"]
+    __slots__ = ["__compact", "__decimal_digits", "__format", "__sep", "__type"]
 
     TYPES = {
         2: np.float16,
@@ -29,12 +29,14 @@ class FloatField(Field):
         format: str = "F",
         sep: str = ".",
         value: float | None = None,
+        compact: bool = False,
     ) -> None:
         super().__init__(
             size,
             starting_position,
             value,
         )
+        self.__compact = compact
         self.__decimal_digits = decimal_digits
         self.__format = format
         self.__sep = sep
@@ -62,6 +64,14 @@ class FloatField(Field):
             return np.array([0.0], dtype=self.__type).tobytes()
         else:
             return np.array([self._value], dtype=self.__type).tobytes()
+
+    def _apply_compact(self, value: str) -> str:
+        if self.__compact and 0 < abs(self._value) < 1:
+            if value.startswith("0."):
+                return value[1:]
+            if value.startswith("-0."):
+                return "-" + value[2:]
+        return value
 
     def _textual_write(self) -> str:
         value = ""
@@ -97,6 +107,7 @@ class FloatField(Field):
                     d=self.__decimal_digits,
                     format=formatting_format,
                 ).replace("E", self.__format)
+                value = self._apply_compact(value)
                 if len(value) > self._size:
                     excess = len(value) - self._size
                     new_d = self.__decimal_digits - excess
@@ -107,6 +118,7 @@ class FloatField(Field):
                         d=new_d,
                         format=formatting_format,
                     ).replace("E", self.__format)
+                    value = self._apply_compact(value)
                     if len(value) > self._size:
                         new_d = max(0, new_d - 1)
                         value = "{:.{d}{format}}".format(
@@ -114,6 +126,7 @@ class FloatField(Field):
                             d=new_d,
                             format=formatting_format,
                         ).replace("E", self.__format)
+                        value = self._apply_compact(value)
         return value.rjust(self.size)
 
     @property

--- a/cfinterface/reading/registerreading.py
+++ b/cfinterface/reading/registerreading.py
@@ -82,6 +82,7 @@ class RegisterReading:
         :return: The data from the registers found in the file
         :rtype: RegisterData
         """
+        self.__data = RegisterData(DefaultRegister(data=""))
         self.__repository = factory(self.__storage)(
             content, not isfile(content), encoding
         )

--- a/tests/components/test_floatfield.py
+++ b/tests/components/test_floatfield.py
@@ -196,3 +196,108 @@ def test_floatfield_write_fuzz_equivalence():
             f"Mismatch: fmt={fmt} size={size} dec={dec} val={val} "
             f"got={result!r} expected={expected!r}"
         )
+
+
+def test_floatfield_compact_positive_small():
+    f = FloatField(5, 0, 4, format="F", value=0.0563, compact=True)
+    assert f._textual_write() == ".0563"
+
+
+def test_floatfield_compact_negative_small():
+    f = FloatField(6, 0, 4, format="F", value=-0.0563, compact=True)
+    assert f._textual_write() == "-.0563"
+
+
+def test_floatfield_compact_no_effect_above_one():
+    f = FloatField(5, 0, 2, format="F", value=1.50, compact=True)
+    assert f._textual_write() == " 1.50"
+
+
+def test_floatfield_compact_no_effect_zero():
+    f = FloatField(6, 0, 3, format="F", value=0.0, compact=True)
+    assert f._textual_write() == " 0.000"
+
+
+def test_floatfield_compact_default_false():
+    f = FloatField(5, 0, 3, format="F", value=0.0563)
+    assert f._textual_write() == "0.056"
+
+
+def test_floatfield_compact_preserves_precision():
+    """Concrete example from issue: size=5, decimal_digits=4.
+
+    Without compact: "0.0563" (6 chars) overflows → reduced to "0.056" (0.53% error).
+    With compact: ".0563" fits in 5 chars → no precision loss.
+    """
+    f_default = FloatField(5, 0, 4, format="F", value=0.0563)
+    f_compact = FloatField(5, 0, 4, format="F", value=0.0563, compact=True)
+    assert f_default._textual_write() == "0.056"
+    assert f_compact._textual_write() == ".0563"
+
+
+def test_floatfield_compact_read_roundtrip():
+    """Reading a compact-formatted value works because float('.0563') parses."""
+    f_write = FloatField(5, 0, 4, format="F", value=0.0563, compact=True)
+    written = f_write._textual_write()
+    assert written == ".0563"
+    line = written + "-rest"
+    f_read = FloatField(5, 0, 4, format="F")
+    f_read.read(line)
+    assert f_read.value == 0.0563
+
+
+def test_floatfield_compact_negative_read_roundtrip():
+    f_write = FloatField(6, 0, 4, format="F", value=-0.0563, compact=True)
+    written = f_write._textual_write()
+    assert written == "-.0563"
+    line = written + "-rest"
+    f_read = FloatField(6, 0, 4, format="F")
+    f_read.read(line)
+    assert f_read.value == -0.0563
+
+
+def test_floatfield_compact_no_effect_negative_zero():
+    f = FloatField(8, 0, 4, format="F", value=-0.0, compact=True)
+    assert f._textual_write() == " -0.0000"
+
+
+def test_floatfield_compact_overflow_still_reduces():
+    """When compact alone doesn't prevent overflow, precision is still reduced."""
+    f = FloatField(4, 0, 4, format="F", value=0.0563, compact=True)
+    result = f._textual_write()
+    assert len(result) == 4
+    assert result == ".056"
+
+
+def test_floatfield_compact_fuzz_properties():
+    """Fuzz: compact output fits field, parses correctly, is at least as precise."""
+    import random
+
+    random.seed(99)
+    for _ in range(50000):
+        size = random.randint(3, 20)
+        dec = random.randint(0, min(10, size - 1))
+        val = random.uniform(-0.999, 0.999)
+        if abs(val) < 1e-15:
+            continue
+        f_default = FloatField(size, 0, dec, format="F", value=val)
+        f_compact = FloatField(
+            size, 0, dec, format="F", value=val, compact=True
+        )
+        default_result = f_default._textual_write()
+        compact_result = f_compact._textual_write()
+        assert len(compact_result) == size, (
+            f"Wrong length: size={size} dec={dec} val={val} "
+            f"compact={compact_result!r} len={len(compact_result)}"
+        )
+        default_float = (
+            float(default_result.strip()) if default_result.strip() else 0.0
+        )
+        compact_float = (
+            float(compact_result.strip()) if compact_result.strip() else 0.0
+        )
+        # Compact must be at least as precise as default
+        assert abs(compact_float - val) <= abs(default_float - val) + 1e-15, (
+            f"Precision loss: size={size} dec={dec} val={val} "
+            f"default={default_result!r} compact={compact_result!r}"
+        )

--- a/tests/files/test_registerfile.py
+++ b/tests/files/test_registerfile.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import warnings
 from io import StringIO
 from unittest.mock import MagicMock, patch
@@ -10,6 +12,8 @@ from cfinterface.components.literalfield import LiteralField
 from cfinterface.components.register import Register
 from cfinterface.data.registerdata import RegisterData
 from cfinterface.files.registerfile import RegisterFile
+from cfinterface.reading.registerreading import RegisterReading
+from cfinterface.storage import StorageType
 from tests.mocks.mock_open import mock_open
 
 
@@ -259,3 +263,41 @@ def test_registerfile_validate_unknown_version():
     f = VersionedRegisterFile.read(filedata)
     result = f.validate(version="v0")
     assert result.matched is False
+
+
+def test_registerreading_data_reset_between_reads():
+    """Verify that RegisterReading.__data is reset on each read() call."""
+    data = "Hello, world!"
+    filedata = DummyRegister.IDENTIFIER + " " + data + "\n"
+    reader = RegisterReading([DummyRegister], StorageType.TEXT)
+    result1 = reader.read(filedata, "utf-8")
+    assert len(result1) == 2  # root DefaultRegister + 1 DummyRegister
+    result2 = reader.read(filedata, "utf-8")
+    assert len(result2) == 2  # must be 2 again, not 4
+
+
+def test_registerfile_read_encoding_fallback_no_duplication():
+    """Verify no data duplication when first encoding fails mid-file.
+
+    A Latin-1 file with a non-UTF-8 byte causes UTF-8 decoding to fail
+    partway through. The fallback to Latin-1 must not carry over partially
+    read data from the failed UTF-8 attempt.
+    """
+    line1 = DummyRegister.IDENTIFIER + " " + "Hello, world!" + "\n"
+    line2 = DummyRegister.IDENTIFIER + " " + "with acc\u00eant! " + "\n"
+
+    class FallbackFile(RegisterFile):
+        REGISTERS = [DummyRegister]
+        ENCODING = ["utf-8", "latin-1"]
+
+    with tempfile.NamedTemporaryFile(
+        mode="wb", suffix=".txt", delete=False
+    ) as f:
+        f.write((line1 + line2).encode("latin-1"))
+        tmppath = f.name
+    try:
+        result = FallbackFile.read(tmppath)
+        # root DefaultRegister + 2 DummyRegisters = 3
+        assert len(result.data) == 3
+    finally:
+        os.unlink(tmppath)


### PR DESCRIPTION
## Summary

- **feat:** Add `compact` parameter to `FloatField` that omits the leading zero for `|value| < 1`, matching Fortran fixed-width conventions and preventing precision loss on round-trip for narrow fields (e.g., `0.0563` → `.0563` in a 5-char field)
- **fix:** Reset `RegisterReading.__data` at the start of each `read()` call, preventing register duplication when `RegisterFile.read()` retries with fallback encodings after a mid-file `UnicodeDecodeError`
- **chore:** Bump version to 1.10.0 and update CHANGELOG

Closes #28

## Test plan

- [x] All 419 existing tests pass with no regressions
- [x] 11 new FloatField compact mode tests (positive/negative, roundtrip, overflow, 50k fuzz)
- [x] 2 new RegisterReading/RegisterFile encoding fallback tests
- [x] Coverage at 94.11% (above 90% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)