### PR TITLE
fix: resolve mypy arg-type error in FloatField._apply_compact

### DIFF
--- a/cfinterface/components/floatfield.py
+++ b/cfinterface/components/floatfield.py
@@ -65,8 +65,8 @@ class FloatField(Field):
         else:
             return np.array([self._value], dtype=self.__type).tobytes()
 
-    def _apply_compact(self, value: str) -> str:
-        if self.__compact and 0 < abs(self._value) < 1:
+    def _apply_compact(self, value: str, numeric: float) -> str:
+        if self.__compact and 0 < abs(numeric) < 1:
             if value.startswith("0."):
                 return value[1:]
             if value.startswith("-0."):
@@ -107,7 +107,7 @@ class FloatField(Field):
                     d=self.__decimal_digits,
                     format=formatting_format,
                 ).replace("E", self.__format)
-                value = self._apply_compact(value)
+                value = self._apply_compact(value, self.value)
                 if len(value) > self._size:
                     excess = len(value) - self._size
                     new_d = self.__decimal_digits - excess
@@ -118,7 +118,7 @@ class FloatField(Field):
                         d=new_d,
                         format=formatting_format,
                     ).replace("E", self.__format)
-                    value = self._apply_compact(value)
+                    value = self._apply_compact(value, self.value)
                     if len(value) > self._size:
                         new_d = max(0, new_d - 1)
                         value = "{:.{d}{format}}".format(
@@ -126,7 +126,7 @@ class FloatField(Field):
                             d=new_d,
                             format=formatting_format,
                         ).replace("E", self.__format)
-                        value = self._apply_compact(value)
+                        value = self._apply_compact(value, self.value)
         return value.rjust(self.size)
 
     @property


### PR DESCRIPTION
## Summary

- Fix mypy `arg-type` error introduced in v1.10.0: `_apply_compact` accessed `self._value` (type `Any | None`) directly with `abs()`, which mypy rejects. Now accepts the numeric value as a parameter, leveraging the caller's `is not None` narrowing.

## Test plan

- [x] `mypy ./cfinterface` passes cleanly (0 errors in 43 files)
- [x] All 419 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)