### PR TITLE
Release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-04-13
+
+### Fixed
+
+- Resolve mypy `arg-type` error in `FloatField._apply_compact` by passing the numeric value as a parameter instead of accessing `self._value` directly
+
 ## [1.10.0] - 2026-04-13
 
 ### Added

--- a/cfinterface/__init__.py
+++ b/cfinterface/__init__.py
@@ -6,7 +6,7 @@ cfi is a Python module for handling custom formatted files
 and provide reading, storing and writing utilities.
 """
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 from . import components  # noqa
 from . import data  # noqa


### PR DESCRIPTION
## Summary

- Patch release fixing mypy `arg-type` error in `FloatField._apply_compact` introduced in v1.10.0
- Version bump to 1.10.1 and CHANGELOG update

## Test plan

- [x] mypy passes cleanly (verified in PR #30 CI)
- [x] All 419 tests pass across Python 3.10-3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)